### PR TITLE
Added gradient background colours to fragments and transparent gradient to home tts 

### DIFF
--- a/app/src/main/res/drawable/backgroundgradient.xml
+++ b/app/src/main/res/drawable/backgroundgradient.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape>
+            <gradient
+                android:angle="90"
+                android:startColor="#FEAC5E"
+                android:endColor="#4BC0C8"
+                android:centerColor="#C779D0"
+                android:type="linear"
+                />
+        </shape>
+    </item>
+
+</selector>

--- a/app/src/main/res/drawable/transgradientbackground.xml
+++ b/app/src/main/res/drawable/transgradientbackground.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape>
+            <gradient
+                android:angle="90"
+                android:startColor="#80FEAC5E"
+                android:endColor="#80C779D0"
+                android:type="linear"
+                />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/layout/fragment_basic.xml
+++ b/app/src/main/res/layout/fragment_basic.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@drawable/backgroundgradient"
     tools:context=".BasicTopic.BasicFragment">
 
 

--- a/app/src/main/res/layout/fragment_category.xml
+++ b/app/src/main/res/layout/fragment_category.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@drawable/backgroundgradient"
     tools:context=".Category.CategoryFragment">
 
     <!-- TODO: Update blank fragment layout -->

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -4,11 +4,13 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@drawable/backgroundgradient"
     tools:context=".Home.HomeFragment">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:background="@drawable/transgradientbackground"
         android:orientation="vertical">
 
 

--- a/app/src/main/res/layout/fragment_quick_action.xml
+++ b/app/src/main/res/layout/fragment_quick_action.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@drawable/backgroundgradient"
     tools:context=".QuickActions.QuickActionFragment">
 
     <!-- TODO: Update blank fragment layout -->

--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -17,6 +17,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
+        android:background="@drawable/backgroundgradient"
+
         android:background="@drawable/default_card_placeholder">
     <de.hdodenhof.circleimageview.CircleImageView
         xmlns:app="http://schemas.android.com/apk/res-auto"


### PR DESCRIPTION
Fixes #54 

Changes: 

- Added gradientbackground files to the drawable so that fragments can use it.
- Added transparent gradient color to home fragment.


 

Screenshots of the change: 
![issue1](https://user-images.githubusercontent.com/31397924/55546484-0dc89d80-56ed-11e9-9c16-2452e6c056f1.png)
![issue2](https://user-images.githubusercontent.com/31397924/55546509-1caf5000-56ed-11e9-9b2a-32fc875b28b3.png)


